### PR TITLE
Deploy with arion

### DIFF
--- a/deploy/arion/README.md
+++ b/deploy/arion/README.md
@@ -1,0 +1,8 @@
+
+# Arion deployment
+
+[Arion](https://github.com/hercules-ci/arion) is a tool that adds a layer of Nix sauce on top of docker-compose.
+
+To deploy an your local docker-compose:
+
+    arion up

--- a/deploy/arion/arion-compose.nix
+++ b/deploy/arion/arion-compose.nix
@@ -1,0 +1,78 @@
+{ pkgs, lib, config, uid, ... }:
+
+let
+  serveStorePath = pkg:
+    let
+      etag = builtins.substring 11 32 "${pkg}";
+    in
+      {
+        root = pkg;
+        extraConfig = ''
+          etag off;
+          add_header etag "${etag}";
+          index index.html;
+        '';
+      };
+  apiInternalURL = "http://backend:8080";
+  # Disambiguate config at the environment level from
+  # config at the service level
+  envConfig = config;
+
+in
+{
+  options.domain = lib.mkOption {
+    type = lib.types.string;
+    default = "localhost:8888";
+  };
+
+  config.docker-compose.services = {
+
+    backend = {
+      service.useHostStore = true;
+      # For example:
+      # service.depends_on = [ "postgres" ];
+      service.command = [ "sh" "-c" ''
+                  ${pkgs.coreutils}/bin/ln -sf ${pkgs.iana-etc}/etc/protocols /etc/protocols
+                  ${pkgs.coreutils}/bin/ln -sf ${pkgs.iana-etc}/etc/services /etc/services
+                  ${pkgs.coreutils}/bin/mkdir -p /etc/ssl/certs/
+                  ${pkgs.coreutils}/bin/ln -sf ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
+                  ${pkgs.coreutils}/bin/ln -sf ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+                  cd /work
+                  ${pkgs.gosu}/bin/gosu ${uid} ${pkgs.backend}/bin/todobackend-scotty
+                '' ];
+      service.environment.PORT = "8080";
+      service.environment.URL = "http://${envConfig.domain}";
+      # For example to mount a directory with 'secrets':
+      service.volumes = [ "${toString ../..}:/work" ];
+    };
+
+    web = {
+      imports = [ ./service-nginx.nix ];
+      service.useHostStore = true;
+      service.depends_on = [ "backend" ];
+      service.ports = [
+        "8888:80" # host:container
+      ];
+      nginx.config = {
+        recommendedOptimisation = true;
+        appendHttpConfig = ''
+          server_names_hash_bucket_size 64;
+          etag off;
+        '';
+        virtualHosts."${envConfig.domain}" = {
+          # forceSSL = true;
+          # enableACME = true;
+          locations."/todos" = {
+            proxyPass = apiInternalURL;
+            proxyWebsockets = false;
+            extraConfig = ''
+              proxy_set_header X-Forwarded-For $remote_addr;
+            '';
+          };
+          locations."/" = serveStorePath "${pkgs.frontend}/var/www";
+        };
+      };
+    };
+  };
+
+}

--- a/deploy/arion/arion-pkgs.nix
+++ b/deploy/arion/arion-pkgs.nix
@@ -1,0 +1,3 @@
+# This file is the default location for Arion to look for Nixpkgs when
+# bootstrapping a deployment configuration.
+import ../../nix {}

--- a/deploy/arion/service-nginx.nix
+++ b/deploy/arion/service-nginx.nix
@@ -1,0 +1,54 @@
+/*
+
+  DISCLAIMER
+
+  This uses a somewhat hidden feature in NixOS, which is the
+  "runner". It's a script that's available on systemd services
+  that lets you run the service independently from systemd.
+  However, it was clearly not intended for public consumption
+  so please use it with care.
+  It does not support all features of systemd so you are on
+  your own if you use it in production.
+
+ */
+
+{ config, pkgs, lib, ... }:
+
+let
+  makeVirtual = {
+    config.boot.loader.grub.enable = false;
+    config.fileSystems."/".device = "/dev/null";
+  };
+
+  inherit (webNixOS) run-nginx;
+
+  webNixOS = pkgs.nixos ({ lib, pkgs, config, ... }: {
+    imports = [makeVirtual];
+    config.system.build.run-nginx = pkgs.writeScript "run-nginx" ''
+      #!${pkgs.bash}/bin/bash
+      PATH='${config.systemd.services.nginx.environment.PATH}'
+      echo nginx:x:${toString config.users.users.nginx.uid}:${toString config.users.groups.nginx.gid}:nginx web server user:/var/empty:/bin/sh >>/etc/passwd
+      echo nginx:x:${toString config.users.groups.nginx.gid}:nginx >>/etc/group
+      ${config.systemd.services.nginx.runner}
+    '';
+
+    config.services.nginx = nginxConfig;
+
+  });
+
+  nginxConfig = lib.mkMerge config.nginx.config;
+
+in
+{
+  options = {
+    nginx.config = lib.mkOption {
+      default = {};
+      type = with lib.types; coercedTo attrs (a: [a]) (listOf attrs);
+    };
+  };
+
+  config = {
+    service.command = [ run-nginx ];
+    nginx.config.enable = true;
+  };
+}

--- a/nix/backend/default.nix
+++ b/nix/backend/default.nix
@@ -1,6 +1,6 @@
 { haskell }:
 # Build a new overlay with our own packages
-haskell.packages.ghc802.extend (self: super: {
+haskell.packages.ghc844.extend (self: super: {
   todobackend-common = self.callPackage ./todobackend-common.nix {};
   todobackend-scotty = self.callPackage ./todobackend-scotty.nix {};
 })

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,27 +1,6 @@
-# https://github.com/NixOS/nixpkgs/pull/30399#issuecomment-340420000
-#
-# Pure fetchTarball with sha256 that works in nix 1.11. This will go away
-# once using nix 1.12+.
 let
   spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
-  src = import <nix/fetchurl.nix> {
+in
+  fetchTarball {
     url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
-    inherit (spec) sha256;
-  };
-  nixcfg = import <nix/config.nix>;
-in builtins.derivation {
-  system = builtins.currentSystem;
-  name = "${src.name}-unpacked";
-  builder = nixcfg.shell;
-  inherit src;
-  args = [
-    (builtins.toFile "builder" ''
-      $coreutils/mkdir $out
-      cd $out
-      $gzip -d < $src | $tar -x --strip-components=1
-    '')
-  ];
-  coreutils = builtins.storePath nixcfg.coreutils;
-  tar = builtins.storePath nixcfg.tar;
-  gzip = builtins.storePath nixcfg.gzip;
-}
+  }

--- a/nix/nixpkgs/example-nix-1.nix
+++ b/nix/nixpkgs/example-nix-1.nix
@@ -1,0 +1,27 @@
+# https://github.com/NixOS/nixpkgs/pull/30399#issuecomment-340420000
+#
+# Pure fetchTarball with sha256 that works in nix 1.11. This will go away
+# once using nix 1.12+.
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+  src = import <nix/fetchurl.nix> {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    inherit (spec) sha256;
+  };
+  nixcfg = import <nix/config.nix>;
+in builtins.derivation {
+  system = builtins.currentSystem;
+  name = "${src.name}-unpacked";
+  builder = nixcfg.shell;
+  inherit src;
+  args = [
+    (builtins.toFile "builder" ''
+      $coreutils/mkdir $out
+      cd $out
+      $gzip -d < $src | $tar -x --strip-components=1
+    '')
+  ];
+  coreutils = builtins.storePath nixcfg.coreutils;
+  tar = builtins.storePath nixcfg.tar;
+  gzip = builtins.storePath nixcfg.gzip;
+}

--- a/nix/nixpkgs/nixpkgs-src.json
+++ b/nix/nixpkgs/nixpkgs-src.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs-channels",
   "branch": "nixpkgs-unstable",
-  "rev": "931a0b8be80661902baefb3e7d55403be893e0e6",
-  "sha256": "0439djlny41x4bnn443lpcrrj4a8gl04hcfj0pqi48hivdxhzc8w"
+  "rev": "61c3169a0e17d789c566d5b241bfe309ce4a6275",
+  "sha256": "1a1avslqs2pn89mk5alc86vbyx03icqic8874m8b03mbr0nis8i0"
 }


### PR DESCRIPTION
I was thinking to promote `todomvc-nix` as the example of how you can use `arion`, a little tool that we want to announce very soon.

It's basically a wrapper around docker-compose with NixOS-style modules. For now it's just local use but that means it can entirely abstract away the use of images!

This PR is not supposed to be merged as is, because I had to do some wrong updates to make it work.
 - Work around #3. It's probably best for one of the pinning guru's to have a look at that issue first.
 - Update nixpkgs to a version that includes `pkgs.nixos`.

I'm using `pkgs.nixos` for a little hack to borrow a bit from the NixOS nginx module. Maybe I should use `caddy` instead? Or that should be optional because `arion-compose.nix` :drum: :drum: :drum: composes.

Arion is currently pre-release / not announced but [available](https://github.com/hercules-ci/arion) for the curious.

Ping @zimbatm 