### PR TITLE
Fix scripts/ci

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 target=nix/release.nix
 buildArgs=(
   "$target"
-  --no-out-links
+  --no-out-link
 )
 
 nix-build "${buildArgs[@]}"


### PR DESCRIPTION
Newer versions of nix only accept a --no-out-link without the plural