### PR TITLE
docs: stop pointing users to an outdated repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add the following code into your `configuration.nix`:
 Clone this repository, and enter into it:
 
 ```
-$ git clone https://github.com/numtide/todomvc-nix/tree/flake
+$ git clone https://github.com/nix-community/todomvc-nix/tree/flake
 $ cd todomvc-nix
 ```
 


### PR DESCRIPTION
I was confused when my local said I was up-to-date, but I didn't have the same latest commits that were showing on GitHub.