### PR TITLE
fix(docs): clone url should not contain branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add the following code into your `configuration.nix`:
 Clone this repository, and enter into it:
 
 ```
-$ git clone https://github.com/nix-community/todomvc-nix/tree/flake
+$ git clone https://github.com/nix-community/todomvc-nix.git
 $ cd todomvc-nix
 ```
 


### PR DESCRIPTION
Use `git clone <url> -b <branch>` to clone a branch.
`flake` branch doesn't exist anymore anyway so using master.